### PR TITLE
Added compatibility for nowprototypeit's auto-wiring of plugins from routers

### DIFF
--- a/now-prototype-it.config.json
+++ b/now-prototype-it.config.json
@@ -1,11 +1,16 @@
 {
+  "version-2024-03": {
     "meta": {
       "description": "An example of a partial user-journey coming from a plugin."
     },
     "pluginDependencies": [
-      "govuk-frontend"
+      "@nowprototypeit/govuk-frontend-adaptor"
     ],
     "nunjucksPaths": [
       "/views"
+    ],
+    "expressRouters": [
+      "/routers/nowprototypeit.js"
     ]
+  }
 }

--- a/routers/nowprototypeit.js
+++ b/routers/nowprototypeit.js
@@ -1,0 +1,7 @@
+const setupRouter = require('../index')
+
+module.exports = {
+  setupGlobalRouter: (router) => {
+    setupRouter(router)
+  }
+}


### PR DESCRIPTION
Hi,

I've been working on `nowprototypeit` which is an open source prototype kit, it's compatible with the GOV.UK kit but has more features.

I've been meaning to explore something similar to what you've done here and it's great to see a realistic use-case for this behaviour.

I've just released version `0.8.0` of `nowprototypeit` which supports plugins from routers.  This PR adds that integration while still supporting your existing example.  Users of `nowprototypeit` don't have to add anything to their `routes.js`, it's a small difference but I've seen users get confused when they uninstall a plugin and their routes file breaks.

You can use the same instructions as in your blog post, but start with a now prototype it kit (`npx nowprototypeit create`) and install the plugin through the UI.  If you want to start with a GOV.UK style kit you can run `npx nowprototypeit --variant=@nowprototypeit/govuk-frontend-adaptor create`.

Here's a thorough with the steps I took to make sure it's all compatible:

1. `npx nowprototypeit create journey-example`
2. `cd journey-example`
3. `npm run dev`
4. Visit Manage Prototype, settings, experiments and turn on the in-browser editor
5. Visit Manage Prototype, Plugins, Lookup a specific plugin
6. Choose Github as the source of the plugin
7. Enter the organisation name `nataliecarey`, the project name `govuk-prototype-kit-journey-plugin` and the branch `nowprototypeit-plugin-routers`, press Lookup, then install the plugin
8. Visit Manage Prototype, Templates and create a Blank GOV.UK Page called `/index`
9. Visit the new homepage and use the in-browser editor button in the top-right corner to edit the page and add the following to the `content` block

```
  <div class="govuk-grid-row">
    <div class="govuk-grid-column-two-thirds">

      <h1 class="govuk-heading-xl">
        {{ serviceName }}
      </h1>

      <ul class="govuk-list govuk-list--bullet">
        <li>update your name, date of birth and National Insurance Number</li>
      </ul>

      {{ 
        govukButton({
          text: "Start now",
          href: "/journey-plugin/start?journey_plugin_exit_url=/end-page",
          isStartButton: true
        })
      }}

    </div>

  </div>
```

10. Visit Manage Prototype, Templates and create a Confirmation Page called `/end-page`
11. Visit Manage Prototype, Settings, Plugin-specific settings for GOV.UK Frontend Adaptor, then set the Service Name
12. Click "Back to your prototype" and you'll be able to use the prototype with the journey from the plugin

If you want me to set up a variant for you I'm happy to do that too, that would allow users to create a new kit with these pages already set up and the relevant plugins installed (it'd be another PR to your project as variants aren't managed centrally).